### PR TITLE
Fix critical bug and prevent duplicate phone or email and no-op edits

### DIFF
--- a/src/main/java/seedu/guestnote/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/guestnote/logic/commands/EditCommand.java
@@ -50,6 +50,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Guest: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This guest already exists in the guestnote book.";
+    public static final String MESSAGE_EDIT_DUPLICATE_PERSON = "No fields have been edited.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
@@ -78,7 +79,11 @@ public class EditCommand extends Command {
         Guest guestToEdit = lastShownList.get(index.getZeroBased());
         Guest editedGuest = createEditedPerson(guestToEdit, editPersonDescriptor);
 
-        if (!guestToEdit.isSameGuest(editedGuest) && model.hasPerson(editedGuest)) {
+        if (guestToEdit.equals(editedGuest)) {
+            throw new CommandException(MESSAGE_EDIT_DUPLICATE_PERSON);
+        }
+
+        if (model.hasGuestWithDuplicatePhoneOrEmailExcluding(editedGuest, guestToEdit)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 

--- a/src/main/java/seedu/guestnote/model/Model.java
+++ b/src/main/java/seedu/guestnote/model/Model.java
@@ -76,6 +76,16 @@ public interface Model {
      */
     void setPerson(Guest target, Guest editedGuest);
 
+    /**
+     * Returns true if there exists another guest in the guest list (excluding {@code guestToExclude})
+     * that has the same phone number or email as {@code guestToCheck}.
+     *
+     * <p>This is used to enforce uniqueness constraints on phone and email fields
+     * during operations like editing a guest, ensuring no duplicate phone or email values exist.</p>
+     */
+    boolean hasGuestWithDuplicatePhoneOrEmailExcluding(Guest guestToCheck, Guest guestToExclude);
+
+
     /** Returns an unmodifiable view of the filtered guest list */
     ObservableList<Guest> getFilteredPersonList();
 

--- a/src/main/java/seedu/guestnote/model/ModelManager.java
+++ b/src/main/java/seedu/guestnote/model/ModelManager.java
@@ -111,6 +111,15 @@ public class ModelManager implements Model {
         guestBook.setGuest(target, editedGuest);
     }
 
+    @Override
+    public boolean hasGuestWithDuplicatePhoneOrEmailExcluding(Guest editedGuest, Guest guestToExclude) {
+        return guestBook.getGuestList().stream()
+                .filter(g -> !g.equals(guestToExclude))
+                .anyMatch(g -> g.getPhone().equals(editedGuest.getPhone())
+                        || g.getEmail().equals(editedGuest.getEmail()));
+    }
+
+
     //=========== Filtered Guest List Accessors =============================================================
 
     /**

--- a/src/main/java/seedu/guestnote/model/request/Request.java
+++ b/src/main/java/seedu/guestnote/model/request/Request.java
@@ -42,7 +42,7 @@ public class Request {
         }
 
         return otherRequest != null
-                && otherRequest.requestName.equals(requestName);
+                && otherRequest.requestName.toLowerCase().equals(requestName.toLowerCase());
     }
 
     @Override

--- a/src/test/java/seedu/guestnote/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/guestnote/logic/commands/AddCommandTest.java
@@ -149,6 +149,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean hasGuestWithDuplicatePhoneOrEmailExcluding(Guest guestToCheck, Guest guestToExclude) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Guest> getFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/guestnote/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/guestnote/logic/commands/EditCommandTest.java
@@ -71,18 +71,6 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());
-        Guest editedGuest = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedGuest));
-
-        Model expectedModel = new ModelManager(new GuestBook(model.getAddressBook()), new UserPrefs());
-
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
-    }
-
-    @Test
     public void execute_filteredList_success() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
@@ -97,6 +85,13 @@ public class EditCommandTest {
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedGuest);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_noFieldSpecifiedUnfilteredList_failure() {
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());
+
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_EDIT_DUPLICATE_PERSON);
     }
 
     @Test


### PR DESCRIPTION
1. Fixed a bug where EditCommand allowed edits that resulted in duplicate phone numbers or emails when only one field was modified. 
2. Also added a check to disallow edits where no actual changes were made to the guest.

**NOTE: ONLY MERGE THIS PR IF ORIGINAL CONSTRAINTS FOR GUEST UNIQUENESS ARE TO BE MAINTAINED**