### PR TITLE
Add check-in / check-out commands and status field to Guest

### DIFF
--- a/src/main/java/seedu/guestnote/logic/commands/CheckInCommand.java
+++ b/src/main/java/seedu/guestnote/logic/commands/CheckInCommand.java
@@ -80,7 +80,7 @@ public class CheckInCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof CheckOutCommand)) {
+        if (!(other instanceof CheckInCommand)) {
             return false;
         }
 

--- a/src/main/java/seedu/guestnote/logic/commands/CheckInCommand.java
+++ b/src/main/java/seedu/guestnote/logic/commands/CheckInCommand.java
@@ -1,0 +1,94 @@
+package seedu.guestnote.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.guestnote.commons.core.index.Index;
+import seedu.guestnote.commons.util.ToStringBuilder;
+import seedu.guestnote.logic.Messages;
+import seedu.guestnote.logic.commands.exceptions.CommandException;
+import seedu.guestnote.model.Model;
+import seedu.guestnote.model.guest.Guest;
+import seedu.guestnote.model.guest.Status;
+import seedu.guestnote.model.request.UniqueRequestList;
+
+/**
+ * Checks in a guest identified using it's displayed index from the guestnote book.
+ */
+public class CheckInCommand extends Command {
+    public static final String COMMAND_WORD = "check-in";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Checks in the guest identified by the index number used in the displayed guest list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+    public static final String MESSAGE_SUCCESS = "Checked in: %1$s";
+    public static final String MESSAGE_ALREADY_CHECKED_IN = "Guest is already checked in.";
+    public static final String MESSAGE_ALREADY_CHECKED_OUT = "Guest has already checked out.";
+
+    private final Index targetIndex;
+
+    public CheckInCommand(Index targetIndex) {
+        requireNonNull(targetIndex);
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Guest> lastShownList = model.getFilteredPersonList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Guest guestToCheckIn = lastShownList.get(targetIndex.getZeroBased());
+
+        if (guestToCheckIn.getStatus() == Status.CHECKED_IN) {
+            throw new CommandException(MESSAGE_ALREADY_CHECKED_IN);
+        }
+
+        if (guestToCheckIn.getStatus() == Status.CHECKED_OUT) {
+            throw new CommandException(MESSAGE_ALREADY_CHECKED_OUT);
+        }
+
+        UniqueRequestList updatedRequests = new UniqueRequestList();
+        updatedRequests.setRequests(guestToCheckIn.getRequests());
+
+        Guest checkedInGuest = new Guest(
+                guestToCheckIn.getName(),
+                guestToCheckIn.getPhone(),
+                guestToCheckIn.getEmail(),
+                guestToCheckIn.getRoomNumber(),
+                Status.CHECKED_IN,
+                updatedRequests
+        );
+
+        model.setPerson(guestToCheckIn, checkedInGuest);
+        model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(checkedInGuest)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof CheckOutCommand)) {
+            return false;
+        }
+
+        CheckInCommand otherCheckInCommand = (CheckInCommand) other;
+        return targetIndex.equals(otherCheckInCommand.targetIndex);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("targetIndex", targetIndex)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/guestnote/logic/commands/CheckInCommand.java
+++ b/src/main/java/seedu/guestnote/logic/commands/CheckInCommand.java
@@ -28,6 +28,9 @@ public class CheckInCommand extends Command {
 
     private final Index targetIndex;
 
+    /**
+     * Constructor to set Index for guest to be checked-out.
+     */
     public CheckInCommand(Index targetIndex) {
         requireNonNull(targetIndex);
         this.targetIndex = targetIndex;

--- a/src/main/java/seedu/guestnote/logic/commands/CheckOutCommand.java
+++ b/src/main/java/seedu/guestnote/logic/commands/CheckOutCommand.java
@@ -23,6 +23,7 @@ public class CheckOutCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
     public static final String MESSAGE_SUCCESS = "Checked out: %1$s";
+    public static final String MESSAGE_NOT_CHECKED_IN = "Guest has not checked in.";
     public static final String MESSAGE_ALREADY_CHECKED_OUT = "Guest has already checked out.";
 
     private final Index targetIndex;
@@ -45,6 +46,10 @@ public class CheckOutCommand extends Command {
         }
 
         Guest guestToCheckOut = lastShownList.get(targetIndex.getZeroBased());
+
+        if (guestToCheckOut.getStatus() == Status.BOOKING) {
+            throw new CommandException(MESSAGE_NOT_CHECKED_IN);
+        }
 
         if (guestToCheckOut.getStatus() == Status.CHECKED_OUT) {
             throw new CommandException(MESSAGE_ALREADY_CHECKED_OUT);

--- a/src/main/java/seedu/guestnote/logic/commands/CheckOutCommand.java
+++ b/src/main/java/seedu/guestnote/logic/commands/CheckOutCommand.java
@@ -27,6 +27,9 @@ public class CheckOutCommand extends Command {
 
     private final Index targetIndex;
 
+    /**
+     * Constructor to set Index for guest to be checked-out.
+     */
     public CheckOutCommand(Index targetIndex) {
         requireNonNull(targetIndex);
         this.targetIndex = targetIndex;

--- a/src/main/java/seedu/guestnote/logic/commands/CheckOutCommand.java
+++ b/src/main/java/seedu/guestnote/logic/commands/CheckOutCommand.java
@@ -1,0 +1,89 @@
+package seedu.guestnote.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.guestnote.commons.core.index.Index;
+import seedu.guestnote.commons.util.ToStringBuilder;
+import seedu.guestnote.logic.Messages;
+import seedu.guestnote.logic.commands.exceptions.CommandException;
+import seedu.guestnote.model.Model;
+import seedu.guestnote.model.guest.Guest;
+import seedu.guestnote.model.guest.Status;
+import seedu.guestnote.model.request.UniqueRequestList;
+
+/**
+ * Checks out a guest identified using it's displayed index from the guestnote book.
+ */
+public class CheckOutCommand extends Command {
+    public static final String COMMAND_WORD = "check-out";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Checks out the guest identified by the index number used in the displayed guest list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+    public static final String MESSAGE_SUCCESS = "Checked out: %1$s";
+    public static final String MESSAGE_ALREADY_CHECKED_OUT = "Guest has already checked out.";
+
+    private final Index targetIndex;
+
+    public CheckOutCommand(Index targetIndex) {
+        requireNonNull(targetIndex);
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Guest> lastShownList = model.getFilteredPersonList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Guest guestToCheckOut = lastShownList.get(targetIndex.getZeroBased());
+
+        if (guestToCheckOut.getStatus() == Status.CHECKED_OUT) {
+            throw new CommandException(MESSAGE_ALREADY_CHECKED_OUT);
+        }
+
+        UniqueRequestList updatedRequests = new UniqueRequestList();
+        updatedRequests.setRequests(guestToCheckOut.getRequests());
+
+        Guest checkedOutGuest = new Guest(
+                guestToCheckOut.getName(),
+                guestToCheckOut.getPhone(),
+                guestToCheckOut.getEmail(),
+                guestToCheckOut.getRoomNumber(),
+                Status.CHECKED_OUT,
+                updatedRequests
+        );
+
+        model.setPerson(guestToCheckOut, checkedOutGuest);
+        model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(checkedOutGuest)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof CheckOutCommand)) {
+            return false;
+        }
+
+        CheckOutCommand otherCheckOutCommand = (CheckOutCommand) other;
+        return targetIndex.equals(otherCheckOutCommand.targetIndex);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("targetIndex", targetIndex)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/guestnote/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/guestnote/logic/commands/EditCommand.java
@@ -24,6 +24,7 @@ import seedu.guestnote.model.guest.Guest;
 import seedu.guestnote.model.guest.Name;
 import seedu.guestnote.model.guest.Phone;
 import seedu.guestnote.model.guest.RoomNumber;
+import seedu.guestnote.model.guest.Status;
 import seedu.guestnote.model.request.UniqueRequestList;
 
 /**
@@ -98,6 +99,7 @@ public class EditCommand extends Command {
         Phone updatedPhone = editPersonDescriptor.getPhone().orElse(guestToEdit.getPhone());
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(guestToEdit.getEmail());
         RoomNumber updatedRoomNumber = editPersonDescriptor.getRoomNumber().orElse(guestToEdit.getRoomNumber());
+        Status updatedStatus = guestToEdit.getStatus();
 
         // Extract existing requests and apply additions/removals
         UniqueRequestList updatedRequests = new UniqueRequestList();
@@ -106,7 +108,7 @@ public class EditCommand extends Command {
         editPersonDescriptor.getRequestsToAdd().ifPresent(updatedRequests::addAll);
         editPersonDescriptor.getRequestsToDelete().ifPresent(updatedRequests::removeAll);
 
-        return new Guest(updatedName, updatedPhone, updatedEmail, updatedRoomNumber, updatedRequests);
+        return new Guest(updatedName, updatedPhone, updatedEmail, updatedRoomNumber, updatedStatus, updatedRequests);
     }
 
     @Override

--- a/src/main/java/seedu/guestnote/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/guestnote/logic/parser/AddCommandParser.java
@@ -16,6 +16,7 @@ import seedu.guestnote.model.guest.Guest;
 import seedu.guestnote.model.guest.Name;
 import seedu.guestnote.model.guest.Phone;
 import seedu.guestnote.model.guest.RoomNumber;
+import seedu.guestnote.model.guest.Status;
 import seedu.guestnote.model.request.UniqueRequestList;
 
 /**
@@ -45,9 +46,10 @@ public class AddCommandParser implements Parser<AddCommand> {
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         RoomNumber roomNumber = ParserUtil.parseRoomNumber(argMultimap.getValue(PREFIX_ROOMNUMBER).get());
+        Status status = Status.BOOKING;
         UniqueRequestList requestList = ParserUtil.parseRequests(argMultimap.getAllValues(PREFIX_REQUEST));
 
-        Guest guest = new Guest(name, phone, email, roomNumber, requestList);
+        Guest guest = new Guest(name, phone, email, roomNumber, status, requestList);
 
         return new AddCommand(guest);
     }

--- a/src/main/java/seedu/guestnote/logic/parser/CheckInCommandParser.java
+++ b/src/main/java/seedu/guestnote/logic/parser/CheckInCommandParser.java
@@ -1,0 +1,28 @@
+package seedu.guestnote.logic.parser;
+
+import static seedu.guestnote.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.guestnote.commons.core.index.Index;
+import seedu.guestnote.logic.commands.CheckInCommand;
+import seedu.guestnote.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new CheckInCommand object
+ */
+public class CheckInCommandParser implements Parser<CheckInCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the CheckInCommand
+     * and returns a CheckInCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public CheckInCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new CheckInCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, CheckInCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/guestnote/logic/parser/CheckOutCommandParser.java
+++ b/src/main/java/seedu/guestnote/logic/parser/CheckOutCommandParser.java
@@ -1,0 +1,28 @@
+package seedu.guestnote.logic.parser;
+
+import static seedu.guestnote.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.guestnote.commons.core.index.Index;
+import seedu.guestnote.logic.commands.CheckOutCommand;
+import seedu.guestnote.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new CheckOutCommand object
+ */
+public class CheckOutCommandParser implements Parser<CheckOutCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the CheckOutCommand
+     * and returns a CheckOutCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public CheckOutCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new CheckOutCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, CheckOutCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/guestnote/logic/parser/GuestBookParser.java
+++ b/src/main/java/seedu/guestnote/logic/parser/GuestBookParser.java
@@ -9,6 +9,8 @@ import java.util.regex.Pattern;
 
 import seedu.guestnote.commons.core.LogsCenter;
 import seedu.guestnote.logic.commands.AddCommand;
+import seedu.guestnote.logic.commands.CheckInCommand;
+import seedu.guestnote.logic.commands.CheckOutCommand;
 import seedu.guestnote.logic.commands.ClearCommand;
 import seedu.guestnote.logic.commands.Command;
 import seedu.guestnote.logic.commands.DeleteCommand;
@@ -61,6 +63,12 @@ public class GuestBookParser {
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
+
+        case CheckInCommand.COMMAND_WORD:
+            return new CheckInCommandParser().parse(arguments);
+
+        case CheckOutCommand.COMMAND_WORD:
+            return new CheckOutCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();

--- a/src/main/java/seedu/guestnote/model/guest/Guest.java
+++ b/src/main/java/seedu/guestnote/model/guest/Guest.java
@@ -29,7 +29,8 @@ public class Guest {
     /**
      * Every field must be present and not null.
      */
-    public Guest(Name name, Phone phone, Email email, RoomNumber roomNumber, Status status, UniqueRequestList requests) {
+    public Guest(Name name, Phone phone, Email email, RoomNumber roomNumber, Status status,
+                 UniqueRequestList requests) {
         requireAllNonNull(name, phone, email, requests);
         this.name = name;
         this.phone = phone;
@@ -54,7 +55,10 @@ public class Guest {
     public RoomNumber getRoomNumber() {
         return roomNumber;
     }
-    public Status getStatus() { return status;}
+
+    public Status getStatus() {
+        return status;
+    }
 
     /**
      * Returns an immutable request set, which throws {@code UnsupportedOperationException}

--- a/src/main/java/seedu/guestnote/model/guest/Guest.java
+++ b/src/main/java/seedu/guestnote/model/guest/Guest.java
@@ -23,17 +23,19 @@ public class Guest {
 
     // Data fields
     private final RoomNumber roomNumber;
+    private final Status status;
     private final UniqueRequestList requests = new UniqueRequestList();
 
     /**
      * Every field must be present and not null.
      */
-    public Guest(Name name, Phone phone, Email email, RoomNumber roomNumber, UniqueRequestList requests) {
+    public Guest(Name name, Phone phone, Email email, RoomNumber roomNumber, Status status, UniqueRequestList requests) {
         requireAllNonNull(name, phone, email, requests);
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.roomNumber = roomNumber;
+        this.status = status;
         this.requests.setRequests(requests);
     }
 
@@ -52,6 +54,7 @@ public class Guest {
     public RoomNumber getRoomNumber() {
         return roomNumber;
     }
+    public Status getStatus() { return status;}
 
     /**
      * Returns an immutable request set, which throws {@code UnsupportedOperationException}
@@ -95,13 +98,14 @@ public class Guest {
                 && phone.equals(otherGuest.phone)
                 && email.equals(otherGuest.email)
                 && roomNumber.equals(otherGuest.roomNumber)
+                && status.equals(otherGuest.status)
                 && requests.equals(otherGuest.requests);
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, roomNumber, requests);
+        return Objects.hash(name, phone, email, roomNumber, status, requests);
     }
 
     @Override
@@ -111,6 +115,7 @@ public class Guest {
                 .add("phone", phone)
                 .add("email", email)
                 .add("roomNumber", roomNumber)
+                .add("status", status)
                 .add("requests", requests)
                 .toString();
     }

--- a/src/main/java/seedu/guestnote/model/guest/Status.java
+++ b/src/main/java/seedu/guestnote/model/guest/Status.java
@@ -1,0 +1,7 @@
+package seedu.guestnote.model.guest;
+
+public enum Status {
+    BOOKING,
+    CHECKED_IN,
+    CHECKED_OUT
+}

--- a/src/main/java/seedu/guestnote/model/guest/Status.java
+++ b/src/main/java/seedu/guestnote/model/guest/Status.java
@@ -1,5 +1,8 @@
 package seedu.guestnote.model.guest;
 
+/**
+ * Represents the status of a guest in the guestnote book.
+ */
 public enum Status {
     BOOKING,
     CHECKED_IN,

--- a/src/main/java/seedu/guestnote/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/guestnote/model/util/SampleDataUtil.java
@@ -9,6 +9,7 @@ import seedu.guestnote.model.guest.Guest;
 import seedu.guestnote.model.guest.Name;
 import seedu.guestnote.model.guest.Phone;
 import seedu.guestnote.model.guest.RoomNumber;
+import seedu.guestnote.model.guest.Status;
 import seedu.guestnote.model.request.Request;
 import seedu.guestnote.model.request.UniqueRequestList;
 
@@ -19,22 +20,22 @@ public class SampleDataUtil {
     public static Guest[] getSamplePersons() {
         return new Guest[] {
             new Guest(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-                new RoomNumber("12-33"),
+                new RoomNumber("12-33"), Status.BOOKING,
                 getRequestList("friends")),
             new Guest(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
-                new RoomNumber("23-32"),
+                new RoomNumber("23-32"), Status.BOOKING,
                 getRequestList("colleagues", "friends")),
             new Guest(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
-                new RoomNumber("01-57"),
+                new RoomNumber("01-57"), Status.BOOKING,
                 getRequestList("neighbours")),
             new Guest(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
-                new RoomNumber("04-22"),
+                new RoomNumber("04-22"), Status.BOOKING,
                 getRequestList("family")),
             new Guest(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
-                new RoomNumber("02-23"),
+                new RoomNumber("02-23"), Status.BOOKING,
                 getRequestList("classmates")),
             new Guest(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
-                new RoomNumber("11-33"),
+                new RoomNumber("11-33"), Status.BOOKING,
                 getRequestList("colleagues"))
         };
     }

--- a/src/main/java/seedu/guestnote/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/guestnote/storage/JsonAdaptedPerson.java
@@ -13,6 +13,7 @@ import seedu.guestnote.model.guest.Guest;
 import seedu.guestnote.model.guest.Name;
 import seedu.guestnote.model.guest.Phone;
 import seedu.guestnote.model.guest.RoomNumber;
+import seedu.guestnote.model.guest.Status;
 import seedu.guestnote.model.request.UniqueRequestList;
 
 /**
@@ -26,6 +27,7 @@ class JsonAdaptedPerson {
     private final String phone;
     private final String email;
     private final String roomNumber;
+    private final String status;
     private final List<JsonAdaptedRequest> requests = new ArrayList<>();
 
     /**
@@ -37,11 +39,13 @@ class JsonAdaptedPerson {
             @JsonProperty("phone") String phone,
             @JsonProperty("email") String email,
             @JsonProperty("roomNumber") String roomNumber,
+            @JsonProperty("status") String status,
             @JsonProperty("requests") List<JsonAdaptedRequest> requests) {
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.roomNumber = roomNumber;
+        this.status = status;
         if (requests != null) {
             this.requests.addAll(requests);
         }
@@ -55,6 +59,7 @@ class JsonAdaptedPerson {
         phone = source.getPhone().value;
         email = source.getEmail().value;
         roomNumber = source.getRoomNumber().roomNumber;
+        status = source.getStatus().name();
         requests.addAll(source.getRequests().stream()
                 .map(JsonAdaptedRequest::new)
                 .collect(Collectors.toList()));
@@ -105,9 +110,14 @@ class JsonAdaptedPerson {
         }
         final RoomNumber modelRoomNumber = new RoomNumber(roomNumber);
 
+        if (status == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Status.class.getSimpleName()));
+        }
+        final Status modelStatus = Status.valueOf(status);
+
         final UniqueRequestList modelRequests = new UniqueRequestList();
         modelRequests.setRequests(personRequests);
-        return new Guest(modelName, modelPhone, modelEmail, modelRoomNumber, modelRequests);
+        return new Guest(modelName, modelPhone, modelEmail, modelRoomNumber, modelStatus, modelRequests);
     }
 
 }

--- a/src/main/java/seedu/guestnote/ui/PersonCard.java
+++ b/src/main/java/seedu/guestnote/ui/PersonCard.java
@@ -37,6 +37,8 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private FlowPane roomNumber;
     @FXML
+    private FlowPane status;
+    @FXML
     private FlowPane requests;
 
 
@@ -51,6 +53,28 @@ public class PersonCard extends UiPart<Region> {
         phone.setText(guest.getPhone().value);
         email.setText(guest.getEmail().value);
         roomNumber.getChildren().add(new Label(guest.getRoomNumber().roomNumber));
+        Label statusLabel = new Label(guest.getStatus().name());
+        statusLabel.getStyleClass().add("status-label");
+
+        switch (guest.getStatus()) {
+
+        case BOOKING:
+            statusLabel.getStyleClass().add("status-booking");
+            break;
+        case CHECKED_IN:
+            statusLabel.getStyleClass().add("status-checkedin");
+            break;
+        case CHECKED_OUT:
+            statusLabel.getStyleClass().add("status-checkedout");
+            break;
+
+        default:
+            break;
+        }
+
+
+        status.getChildren().add(statusLabel);
+
         final int[] counter = {1};
         guest.getRequests()
                 .forEach(request -> {

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -367,3 +367,30 @@
     -fx-background-radius: 2;
     -fx-font-size: 11;
 }
+
+#status {
+    -fx-hgap: 15;
+    -fx-vgap: 10;
+}
+
+.status-label {
+    -fx-translate-y: 2px;
+    -fx-padding: 1 4 1 4;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 11;
+    -fx-font-family: "Segoe UI Semibold";
+    -fx-text-fill: white;
+}
+
+.status-booking {
+    -fx-background-color: #cca33b; /* yellow */
+}
+
+.status-checkedin {
+    -fx-background-color: #3cb371; /* medium green */
+}
+
+.status-checkedout {
+    -fx-background-color: #d94f4f; /* soft red */
+}

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -14,31 +14,23 @@
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
     </columnConstraints>
-    <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+    <VBox alignment="CENTER_LEFT" minHeight="120" spacing="5" GridPane.columnIndex="0">
       <padding>
         <Insets top="5" right="5" bottom="5" left="15" />
       </padding>
 
-        <HBox spacing="0.5" alignment="CENTER_LEFT">
-          <Label fx:id="id" styleClass="cell_big_label">
-            <minWidth>
-              <!-- Ensures that the label text is never truncated -->
-              <Region fx:constant="USE_PREF_SIZE" />
-            </minWidth>
-          </Label>
-          <FlowPane fx:id="roomNumber"
-                    alignment="TOP_LEFT"
-                    vgap="0" hgap="3"
-                    maxWidth="40" />
-          <Label fx:id="name" styleClass="cell_big_label"/>
-        </HBox>
+      <HBox spacing="0.5" alignment="CENTER_LEFT">
+        <Label fx:id="id" styleClass="cell_big_label"/>
+        <FlowPane fx:id="roomNumber" alignment="TOP_LEFT" vgap="0" hgap="3" maxWidth="40" />
+        <Label fx:id="name" styleClass="cell_big_label"/>
+      </HBox>
 
-      <FlowPane fx:id="requests"
-                hgap="5" vgap="3"
-                prefWrapLength="300" />
-      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
-      <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+      <FlowPane fx:id="status" alignment="TOP_LEFT" vgap="3" hgap="5" />
 
+      <FlowPane fx:id="requests" hgap="5" vgap="3" prefWrapLength="300" />
+      <Label fx:id="phone" styleClass="cell_small_label" />
+      <Label fx:id="email" styleClass="cell_small_label" />
     </VBox>
+
   </GridPane>
 </HBox>

--- a/src/test/data/JsonGuestBookStorageTest/invalidAndValidPersonGuestBook.json
+++ b/src/test/data/JsonGuestBookStorageTest/invalidAndValidPersonGuestBook.json
@@ -3,11 +3,13 @@
     "name": "Valid Person",
     "phone": "9482424",
     "email": "hans@example.com",
-    "roomNumber": "04-22"
+    "roomNumber": "04-22",
+    "status": "BOOKING"
   }, {
     "name": "Person With Invalid Phone Field",
     "phone": "948asdf2424",
     "email": "hans@example.com",
-    "roomNumber": "04-22"
+    "roomNumber": "04-22",
+    "status": "BOOKING"
   } ]
 }

--- a/src/test/data/JsonGuestBookStorageTest/invalidPersonGuestBook.json
+++ b/src/test/data/JsonGuestBookStorageTest/invalidPersonGuestBook.json
@@ -3,6 +3,7 @@
     "name": "Person with invalid name field: Ha!ns Mu@ster",
     "phone": "9482424",
     "email": "hans@example.com",
-    "roomNumber": "04-22"
+    "roomNumber": "04-22",
+    "status": "BOOKING"
   } ]
 }

--- a/src/test/data/JsonSerializableGuestBookTest/duplicatePersonGuestBook.json
+++ b/src/test/data/JsonSerializableGuestBookTest/duplicatePersonGuestBook.json
@@ -4,11 +4,13 @@
     "phone": "94351253",
     "email": "alice@example.com",
     "roomNumber": "04-22",
+    "status": "BOOKING",
     "requests": [ "friend" ]
   }, {
     "name": "Alice Pauline",
     "phone": "94351253",
     "email": "pauline@example.com",
-    "roomNumber": "04-22"
+    "roomNumber": "04-22",
+    "status": "BOOKING"
   } ]
 }

--- a/src/test/data/JsonSerializableGuestBookTest/invalidPersonGuestBook.json
+++ b/src/test/data/JsonSerializableGuestBookTest/invalidPersonGuestBook.json
@@ -2,6 +2,8 @@
   "persons": [ {
     "name": "Hans Muster",
     "phone": "9482424",
-    "email": "invalid@email!3e"
+    "email": "invalid@email!3e",
+    "roomNumber": "04-22",
+    "status": "BOOKING"
   } ]
 }

--- a/src/test/data/JsonSerializableGuestBookTest/typicalPersonsGuestBook.json
+++ b/src/test/data/JsonSerializableGuestBookTest/typicalPersonsGuestBook.json
@@ -5,42 +5,49 @@
     "phone" : "94351253",
     "email" : "alice@example.com",
     "roomNumber" : "12-33",
+    "status" : "BOOKING",
     "requests" : [ "friend" ]
   }, {
     "name" : "Benson Meier",
     "phone" : "98765432",
     "email" : "johnd@example.com",
     "roomNumber" : "23-32",
+    "status" : "BOOKING",
     "requests" : [ "owesMoney", "friend" ]
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",
     "email" : "heinz@example.com",
     "roomNumber" : "01-57",
+    "status" : "BOOKING",
     "requests" : [ ]
   }, {
     "name" : "Daniel Meier",
     "phone" : "87652533",
     "email" : "cornelia@example.com",
     "roomNumber" : "04-22",
+    "status" : "BOOKING",
     "requests" : [ "friend" ]
   }, {
     "name" : "Elle Meyer",
     "phone" : "9482224",
     "email" : "werner@example.com",
     "roomNumber" : "02-23",
+    "status" : "BOOKING",
     "requests" : [ ]
   }, {
     "name" : "Fiona Kunz",
     "phone" : "9482427",
     "email" : "lydia@example.com",
     "roomNumber" : "11-33",
+    "status" : "BOOKING",
     "requests" : [ ]
   }, {
     "name" : "George Best",
     "phone" : "9482442",
     "email" : "anna@example.com",
     "roomNumber" : "03-33",
+    "status" : "BOOKING",
     "requests" : [ ]
   } ]
 }

--- a/src/test/java/seedu/guestnote/logic/commands/CheckInCommandTest.java
+++ b/src/test/java/seedu/guestnote/logic/commands/CheckInCommandTest.java
@@ -1,0 +1,100 @@
+package seedu.guestnote.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.guestnote.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.guestnote.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.guestnote.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.guestnote.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.guestnote.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.guestnote.commons.core.index.Index;
+import seedu.guestnote.logic.Messages;
+import seedu.guestnote.model.Model;
+import seedu.guestnote.model.ModelManager;
+import seedu.guestnote.model.UserPrefs;
+import seedu.guestnote.model.guest.Guest;
+import seedu.guestnote.model.guest.Status;
+import seedu.guestnote.testutil.PersonBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code CheckInCommand}.
+ */
+public class CheckInCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Guest guestToCheckIn = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        CheckInCommand checkInCommand = new CheckInCommand(INDEX_FIRST_PERSON);
+
+        Guest checkedInGuest = new PersonBuilder(guestToCheckIn).withStatus(Status.CHECKED_IN).build();
+        String expectedMessage = String.format(CheckInCommand.MESSAGE_SUCCESS, Messages.format(checkedInGuest));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.setPerson(guestToCheckIn, checkedInGuest);
+
+        assertCommandSuccess(checkInCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        CheckInCommand checkInCommand = new CheckInCommand(outOfBoundIndex);
+
+        assertCommandFailure(checkInCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_alreadyCheckedIn_throwsCommandException() {
+        Guest guestToCheckIn = new PersonBuilder().withStatus(Status.CHECKED_IN).build();
+        model.setPerson(model.getFilteredPersonList().get(0), guestToCheckIn);
+        CheckInCommand checkInCommand = new CheckInCommand(INDEX_FIRST_PERSON);
+
+        assertCommandFailure(checkInCommand, model, CheckInCommand.MESSAGE_ALREADY_CHECKED_IN);
+    }
+
+    @Test
+    public void execute_alreadyCheckedOut_throwsCommandException() {
+        Guest guestToCheckIn = new PersonBuilder().withStatus(Status.CHECKED_OUT).build();
+        model.setPerson(model.getFilteredPersonList().get(0), guestToCheckIn);
+        CheckInCommand checkInCommand = new CheckInCommand(INDEX_FIRST_PERSON);
+
+        assertCommandFailure(checkInCommand, model, CheckInCommand.MESSAGE_ALREADY_CHECKED_OUT);
+    }
+
+    @Test
+    public void equals() {
+        CheckInCommand checkInFirstCommand = new CheckInCommand(INDEX_FIRST_PERSON);
+        CheckInCommand checkInSecondCommand = new CheckInCommand(INDEX_SECOND_PERSON);
+
+        // same object -> returns true
+        assertTrue(checkInFirstCommand.equals(checkInFirstCommand));
+
+        // same values -> returns true
+        CheckInCommand checkInFirstCommandCopy = new CheckInCommand(INDEX_FIRST_PERSON);
+        assertTrue(checkInFirstCommand.equals(checkInFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(checkInFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(checkInFirstCommand.equals(null));
+
+        // different guest -> returns false
+        assertFalse(checkInFirstCommand.equals(checkInSecondCommand));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index targetIndex = Index.fromOneBased(1);
+        CheckInCommand checkInCommand = new CheckInCommand(targetIndex);
+        String expected = CheckInCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
+        assertEquals(expected, checkInCommand.toString());
+    }
+}

--- a/src/test/java/seedu/guestnote/logic/commands/CheckOutCommandTest.java
+++ b/src/test/java/seedu/guestnote/logic/commands/CheckOutCommandTest.java
@@ -30,7 +30,8 @@ public class CheckOutCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
-        Guest guestToCheckOut = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Guest guestToCheckOut = new PersonBuilder().withStatus(Status.CHECKED_IN).build();
+        model.setPerson(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()), guestToCheckOut);
         CheckOutCommand checkOutCommand = new CheckOutCommand(INDEX_FIRST_PERSON);
 
         Guest checkedOutGuest = new PersonBuilder(guestToCheckOut).withStatus(Status.CHECKED_OUT).build();
@@ -48,6 +49,15 @@ public class CheckOutCommandTest {
         CheckOutCommand checkOutCommand = new CheckOutCommand(outOfBoundIndex);
 
         assertCommandFailure(checkOutCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_bookingStatus_throwsCommandException() {
+        Guest guestToCheckOut = new PersonBuilder().withStatus(Status.BOOKING).build();
+        model.setPerson(model.getFilteredPersonList().get(0), guestToCheckOut);
+        CheckOutCommand checkOutCommand = new CheckOutCommand(INDEX_FIRST_PERSON);
+
+        assertCommandFailure(checkOutCommand, model, CheckOutCommand.MESSAGE_NOT_CHECKED_IN);
     }
 
     @Test

--- a/src/test/java/seedu/guestnote/logic/commands/CheckOutCommandTest.java
+++ b/src/test/java/seedu/guestnote/logic/commands/CheckOutCommandTest.java
@@ -1,0 +1,91 @@
+package seedu.guestnote.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.guestnote.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.guestnote.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.guestnote.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.guestnote.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.guestnote.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.guestnote.commons.core.index.Index;
+import seedu.guestnote.logic.Messages;
+import seedu.guestnote.model.Model;
+import seedu.guestnote.model.ModelManager;
+import seedu.guestnote.model.UserPrefs;
+import seedu.guestnote.model.guest.Guest;
+import seedu.guestnote.model.guest.Status;
+import seedu.guestnote.testutil.PersonBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code CheckOutCommand}.
+ */
+public class CheckOutCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Guest guestToCheckOut = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        CheckOutCommand checkOutCommand = new CheckOutCommand(INDEX_FIRST_PERSON);
+
+        Guest checkedOutGuest = new PersonBuilder(guestToCheckOut).withStatus(Status.CHECKED_OUT).build();
+        String expectedMessage = String.format(CheckOutCommand.MESSAGE_SUCCESS, Messages.format(checkedOutGuest));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.setPerson(guestToCheckOut, checkedOutGuest);
+
+        assertCommandSuccess(checkOutCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        CheckOutCommand checkOutCommand = new CheckOutCommand(outOfBoundIndex);
+
+        assertCommandFailure(checkOutCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_alreadyCheckedOut_throwsCommandException() {
+        Guest guestToCheckOut = new PersonBuilder().withStatus(Status.CHECKED_OUT).build();
+        model.setPerson(model.getFilteredPersonList().get(0), guestToCheckOut);
+        CheckOutCommand checkOutCommand = new CheckOutCommand(INDEX_FIRST_PERSON);
+
+        assertCommandFailure(checkOutCommand, model, CheckOutCommand.MESSAGE_ALREADY_CHECKED_OUT);
+    }
+
+    @Test
+    public void equals() {
+        CheckOutCommand checkOutFirstCommand = new CheckOutCommand(INDEX_FIRST_PERSON);
+        CheckOutCommand checkOutSecondCommand = new CheckOutCommand(INDEX_SECOND_PERSON);
+
+        // same object -> returns true
+        assertTrue(checkOutFirstCommand.equals(checkOutFirstCommand));
+
+        // same values -> returns true
+        CheckOutCommand checkOutFirstCommandCopy = new CheckOutCommand(INDEX_FIRST_PERSON);
+        assertTrue(checkOutFirstCommand.equals(checkOutFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(checkOutFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(checkOutFirstCommand.equals(null));
+
+        // different guest -> returns false
+        assertFalse(checkOutFirstCommand.equals(checkOutSecondCommand));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index targetIndex = Index.fromOneBased(1);
+        CheckOutCommand checkOutCommand = new CheckOutCommand(targetIndex);
+        String expected = CheckOutCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
+        assertEquals(expected, checkOutCommand.toString());
+    }
+}

--- a/src/test/java/seedu/guestnote/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/guestnote/logic/commands/CommandTestUtil.java
@@ -20,6 +20,7 @@ import seedu.guestnote.model.GuestBook;
 import seedu.guestnote.model.Model;
 import seedu.guestnote.model.guest.Guest;
 import seedu.guestnote.model.guest.NameContainsKeywordsPredicate;
+import seedu.guestnote.model.guest.Status;
 import seedu.guestnote.testutil.EditPersonDescriptorBuilder;
 
 /**
@@ -37,6 +38,8 @@ public class CommandTestUtil {
     public static final String VALID_REQUEST_FRIEND = "friend";
     public static final String VALID_ROOMNUMBER_AMY = "12-03";
     public static final String VALID_ROOMNUMBER_BOB = "12-04";
+    public static final Status VALID_STATUS_AMY = Status.BOOKING;
+    public static final Status VALID_STATUS_BOB = Status.BOOKING;
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;

--- a/src/test/java/seedu/guestnote/logic/parser/CheckInCommandParserTest.java
+++ b/src/test/java/seedu/guestnote/logic/parser/CheckInCommandParserTest.java
@@ -1,0 +1,55 @@
+package seedu.guestnote.logic.parser;
+
+import static seedu.guestnote.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.guestnote.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.guestnote.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.guestnote.testutil.Assert.assertThrows;
+import static seedu.guestnote.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.guestnote.logic.commands.CheckInCommand;
+
+/**
+ * Parses input arguments and creates a new CheckInCommand object.
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the CheckInCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the CheckInCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
+public class CheckInCommandParserTest {
+
+    private final CheckInCommandParser parser = new CheckInCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsCheckInCommand() throws Exception {
+        assertParseSuccess(parser, "1", new CheckInCommand(INDEX_FIRST_PERSON));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                CheckInCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_nullArgs_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> parser.parse(null));
+    }
+
+    @Test
+    public void parse_emptyArgs_throwsParseException() {
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT, CheckInCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_whitespaceArgs_throwsParseException() {
+        assertParseFailure(parser, "   ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, CheckInCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_boundaryValues_throwsParseException() {
+        assertParseFailure(parser, "0", String.format(MESSAGE_INVALID_COMMAND_FORMAT, CheckInCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/guestnote/logic/parser/CheckOutCommandParserTest.java
+++ b/src/test/java/seedu/guestnote/logic/parser/CheckOutCommandParserTest.java
@@ -1,0 +1,55 @@
+package seedu.guestnote.logic.parser;
+
+import static seedu.guestnote.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.guestnote.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.guestnote.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.guestnote.testutil.Assert.assertThrows;
+import static seedu.guestnote.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.guestnote.logic.commands.CheckOutCommand;
+
+/**
+ * Parses input arguments and creates a new CheckOutCommand object.
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the CheckOutCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the CheckOutCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
+public class CheckOutCommandParserTest {
+
+    private final CheckOutCommandParser parser = new CheckOutCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsCheckOutCommand() throws Exception {
+        assertParseSuccess(parser, "1", new CheckOutCommand(INDEX_FIRST_PERSON));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                CheckOutCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_nullArgs_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> parser.parse(null));
+    }
+
+    @Test
+    public void parse_emptyArgs_throwsParseException() {
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT, CheckOutCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_whitespaceArgs_throwsParseException() {
+        assertParseFailure(parser, "   ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, CheckOutCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_boundaryValues_throwsParseException() {
+        assertParseFailure(parser, "0", String.format(MESSAGE_INVALID_COMMAND_FORMAT, CheckOutCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/guestnote/logic/parser/GuestBookParserTest.java
+++ b/src/test/java/seedu/guestnote/logic/parser/GuestBookParserTest.java
@@ -14,6 +14,8 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.guestnote.logic.commands.AddCommand;
+import seedu.guestnote.logic.commands.CheckInCommand;
+import seedu.guestnote.logic.commands.CheckOutCommand;
 import seedu.guestnote.logic.commands.ClearCommand;
 import seedu.guestnote.logic.commands.DeleteCommand;
 import seedu.guestnote.logic.commands.EditCommand;
@@ -51,6 +53,20 @@ public class GuestBookParserTest {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+    }
+
+    @Test
+    public void parseCommand_check_in() throws Exception {
+        CheckInCommand command = (CheckInCommand) parser.parseCommand(
+                CheckInCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new CheckInCommand(INDEX_FIRST_PERSON), command);
+    }
+
+    @Test
+    public void parseCommand_check_out() throws Exception {
+        CheckOutCommand command = (CheckOutCommand) parser.parseCommand(
+                CheckOutCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new CheckOutCommand(INDEX_FIRST_PERSON), command);
     }
 
     @Test

--- a/src/test/java/seedu/guestnote/model/guest/GuestTest.java
+++ b/src/test/java/seedu/guestnote/model/guest/GuestTest.java
@@ -88,6 +88,7 @@ public class GuestTest {
     public void toStringMethod() {
         String expected = Guest.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
                 + ", email=" + ALICE.getEmail() + ", roomNumber=" + ALICE.getRoomNumber()
+                + ", status=" + ALICE.getStatus()
                 + ", requests=" + ALICE.getRequests()
                 + "}";
         assertEquals(expected, ALICE.toString());

--- a/src/test/java/seedu/guestnote/model/guest/StatusTest.java
+++ b/src/test/java/seedu/guestnote/model/guest/StatusTest.java
@@ -1,0 +1,61 @@
+package seedu.guestnote.model.guest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.guestnote.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+
+class StatusTest {
+
+    @Test
+    void testBookingStatus() {
+        Status status = Status.BOOKING;
+        assertEquals("BOOKING", status.name());
+        assertEquals(0, status.ordinal());
+    }
+
+    @Test
+    void testCheckedInStatus() {
+        Status status = Status.CHECKED_IN;
+        assertEquals("CHECKED_IN", status.name());
+        assertEquals(1, status.ordinal());
+    }
+
+    @Test
+    void testCheckedOutStatus() {
+        Status status = Status.CHECKED_OUT;
+        assertEquals("CHECKED_OUT", status.name());
+        assertEquals(2, status.ordinal());
+    }
+
+    @Test
+    void testValueOf() {
+        assertEquals(Status.BOOKING, Status.valueOf("BOOKING"));
+        assertEquals(Status.CHECKED_IN, Status.valueOf("CHECKED_IN"));
+        assertEquals(Status.CHECKED_OUT, Status.valueOf("CHECKED_OUT"));
+    }
+
+    @Test
+    void testValues() {
+        Status[] statuses = Status.values();
+        assertEquals(3, statuses.length);
+        assertEquals(Status.BOOKING, statuses[0]);
+        assertEquals(Status.CHECKED_IN, statuses[1]);
+        assertEquals(Status.CHECKED_OUT, statuses[2]);
+    }
+
+    @Test
+    void testValueOfNull() {
+        assertThrows(NullPointerException.class, () -> {
+            Status.valueOf(null);
+        });
+    }
+
+    @Test
+    void testValueOfInvalid() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            Status.valueOf("INVALID_STATUS");
+        });
+    }
+}

--- a/src/test/java/seedu/guestnote/storage/JsonAdaptedGuestTest.java
+++ b/src/test/java/seedu/guestnote/storage/JsonAdaptedGuestTest.java
@@ -27,6 +27,7 @@ public class JsonAdaptedGuestTest {
     private static final String VALID_PHONE = BENSON.getPhone().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
     private static final String VALID_ROOMNUMBER = BENSON.getRoomNumber().toString();
+    private static final String VALID_STATUS = BENSON.getStatus().toString();
     private static final List<JsonAdaptedRequest> VALID_REQUESTS = BENSON.getRequests().stream()
             .map(JsonAdaptedRequest::new)
             .collect(Collectors.toList());
@@ -40,7 +41,7 @@ public class JsonAdaptedGuestTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(
-                INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ROOMNUMBER, VALID_REQUESTS);
+                INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ROOMNUMBER, VALID_STATUS, VALID_REQUESTS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -48,7 +49,7 @@ public class JsonAdaptedGuestTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(
-                null, VALID_PHONE, VALID_EMAIL, VALID_ROOMNUMBER, VALID_REQUESTS);
+                null, VALID_PHONE, VALID_EMAIL, VALID_ROOMNUMBER, VALID_STATUS, VALID_REQUESTS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -57,7 +58,7 @@ public class JsonAdaptedGuestTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(
-                        VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ROOMNUMBER, VALID_REQUESTS);
+                        VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ROOMNUMBER, VALID_STATUS, VALID_REQUESTS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -65,7 +66,7 @@ public class JsonAdaptedGuestTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(
-                VALID_NAME, null, VALID_EMAIL, VALID_ROOMNUMBER, VALID_REQUESTS);
+                VALID_NAME, null, VALID_EMAIL, VALID_ROOMNUMBER, VALID_STATUS, VALID_REQUESTS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -74,7 +75,7 @@ public class JsonAdaptedGuestTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(
-                        VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ROOMNUMBER, VALID_REQUESTS);
+                        VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ROOMNUMBER, VALID_STATUS, VALID_REQUESTS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -82,7 +83,7 @@ public class JsonAdaptedGuestTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(
-                VALID_NAME, VALID_PHONE, null, VALID_ROOMNUMBER, VALID_REQUESTS);
+                VALID_NAME, VALID_PHONE, null, VALID_ROOMNUMBER, VALID_STATUS, VALID_REQUESTS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -90,7 +91,7 @@ public class JsonAdaptedGuestTest {
     @Test
     public void toModelType_invalidRoomNumber_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(
-                        VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ROOMNUMBER, VALID_REQUESTS);
+                        VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ROOMNUMBER, VALID_STATUS, VALID_REQUESTS);
         String expectedMessage = RoomNumber.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -98,7 +99,7 @@ public class JsonAdaptedGuestTest {
     @Test
     public void toModelType_nullRoomNumber_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(
-                VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_REQUESTS);
+                VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_STATUS, VALID_REQUESTS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, RoomNumber.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -108,7 +109,7 @@ public class JsonAdaptedGuestTest {
         List<JsonAdaptedRequest> invalidRequests = new ArrayList<>(VALID_REQUESTS);
         invalidRequests.add(new JsonAdaptedRequest(INVALID_REQUEST));
         JsonAdaptedPerson person = new JsonAdaptedPerson(
-                VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ROOMNUMBER, invalidRequests);
+                VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ROOMNUMBER, VALID_STATUS, invalidRequests);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 

--- a/src/test/java/seedu/guestnote/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/guestnote/testutil/PersonBuilder.java
@@ -5,6 +5,7 @@ import seedu.guestnote.model.guest.Guest;
 import seedu.guestnote.model.guest.Name;
 import seedu.guestnote.model.guest.Phone;
 import seedu.guestnote.model.guest.RoomNumber;
+import seedu.guestnote.model.guest.Status;
 import seedu.guestnote.model.request.UniqueRequestList;
 import seedu.guestnote.model.util.SampleDataUtil;
 
@@ -17,11 +18,13 @@ public class PersonBuilder {
     public static final String DEFAULT_PHONE = "85355255";
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
     public static final String DEFAULT_ROOM_NUMBER = "00-00";
+    public static final Status DEFAULT_STATUS = Status.BOOKING;
 
     private Name name;
     private Phone phone;
     private Email email;
     private RoomNumber roomNumber;
+    private Status status;
     private UniqueRequestList requests;
 
     /**
@@ -32,6 +35,7 @@ public class PersonBuilder {
         phone = new Phone(DEFAULT_PHONE);
         email = new Email(DEFAULT_EMAIL);
         roomNumber = new RoomNumber(DEFAULT_ROOM_NUMBER);
+        status = DEFAULT_STATUS;
         requests = new UniqueRequestList();
     }
 
@@ -43,6 +47,7 @@ public class PersonBuilder {
         phone = guestToCopy.getPhone();
         email = guestToCopy.getEmail();
         roomNumber = guestToCopy.getRoomNumber();
+        status = guestToCopy.getStatus();
         requests = new UniqueRequestList();
         requests.setRequests(guestToCopy.getRequests());
     }
@@ -87,8 +92,16 @@ public class PersonBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code Status} of the {@code Guest} that we are building.
+     */
+    public PersonBuilder withStatus(Status status) {
+        this.status = status;
+        return this;
+    }
+
     public Guest build() {
-        return new Guest(name, phone, email, roomNumber, requests);
+        return new Guest(name, phone, email, roomNumber, status, requests);
     }
 
 }

--- a/src/test/java/seedu/guestnote/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/guestnote/testutil/TypicalPersons.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import seedu.guestnote.model.GuestBook;
 import seedu.guestnote.model.guest.Guest;
+import seedu.guestnote.model.guest.Status;
 
 /**
  * A utility class containing a list of {@code Guest} objects to be used in tests.
@@ -28,13 +29,15 @@ public class TypicalPersons {
             .withEmail("alice@example.com")
             .withPhone("94351253")
             .withRoomNumber("12-33")
-            .withRequests("friend").build();
+            .withRequests("friend")
+            .withStatus(Status.BOOKING).build();
     public static final Guest BENSON = new PersonBuilder()
             .withName("Benson Meier")
             .withEmail("johnd@example.com")
             .withPhone("98765432")
             .withRoomNumber("23-32")
-            .withRequests("owesMoney", "friend").build();
+            .withRequests("owesMoney", "friend")
+            .withStatus(Status.BOOKING).build();
     public static final Guest CARL = new PersonBuilder()
             .withName("Carl Kurz")
             .withEmail("heinz@example.com")

--- a/src/test/java/seedu/guestnote/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/guestnote/testutil/TypicalPersons.java
@@ -1,5 +1,18 @@
 package seedu.guestnote.testutil;
 
+import static seedu.guestnote.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
+import static seedu.guestnote.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.guestnote.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.guestnote.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.guestnote.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
+import static seedu.guestnote.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.guestnote.logic.commands.CommandTestUtil.VALID_REQUEST_FRIEND;
+import static seedu.guestnote.logic.commands.CommandTestUtil.VALID_REQUEST_HUSBAND;
+import static seedu.guestnote.logic.commands.CommandTestUtil.VALID_ROOMNUMBER_AMY;
+import static seedu.guestnote.logic.commands.CommandTestUtil.VALID_ROOMNUMBER_BOB;
+import static seedu.guestnote.logic.commands.CommandTestUtil.VALID_STATUS_AMY;
+import static seedu.guestnote.logic.commands.CommandTestUtil.VALID_STATUS_BOB;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -8,7 +21,6 @@ import seedu.guestnote.model.GuestBook;
 import seedu.guestnote.model.guest.Guest;
 import seedu.guestnote.model.guest.Status;
 
-import static seedu.guestnote.logic.commands.CommandTestUtil.*;
 
 /**
  * A utility class containing a list of {@code Guest} objects to be used in tests.

--- a/src/test/java/seedu/guestnote/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/guestnote/testutil/TypicalPersons.java
@@ -1,16 +1,5 @@
 package seedu.guestnote.testutil;
 
-import static seedu.guestnote.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
-import static seedu.guestnote.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
-import static seedu.guestnote.logic.commands.CommandTestUtil.VALID_NAME_AMY;
-import static seedu.guestnote.logic.commands.CommandTestUtil.VALID_NAME_BOB;
-import static seedu.guestnote.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
-import static seedu.guestnote.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.guestnote.logic.commands.CommandTestUtil.VALID_REQUEST_FRIEND;
-import static seedu.guestnote.logic.commands.CommandTestUtil.VALID_REQUEST_HUSBAND;
-import static seedu.guestnote.logic.commands.CommandTestUtil.VALID_ROOMNUMBER_AMY;
-import static seedu.guestnote.logic.commands.CommandTestUtil.VALID_ROOMNUMBER_BOB;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -18,6 +7,8 @@ import java.util.List;
 import seedu.guestnote.model.GuestBook;
 import seedu.guestnote.model.guest.Guest;
 import seedu.guestnote.model.guest.Status;
+
+import static seedu.guestnote.logic.commands.CommandTestUtil.*;
 
 /**
  * A utility class containing a list of {@code Guest} objects to be used in tests.
@@ -43,6 +34,7 @@ public class TypicalPersons {
             .withEmail("heinz@example.com")
             .withPhone("95352563")
             .withRoomNumber("01-57")
+            .withStatus(Status.BOOKING)
             .build();
     public static final Guest DANIEL = new PersonBuilder()
             .withName("Daniel Meier")
@@ -50,24 +42,28 @@ public class TypicalPersons {
             .withPhone("87652533")
             .withRoomNumber("04-22")
             .withRequests("friend")
+            .withStatus(Status.BOOKING)
             .build();
     public static final Guest ELLE = new PersonBuilder()
             .withName("Elle Meyer")
             .withEmail("werner@example.com")
             .withPhone("9482224")
             .withRoomNumber("02-23")
+            .withStatus(Status.BOOKING)
             .build();
     public static final Guest FIONA = new PersonBuilder()
             .withName("Fiona Kunz")
             .withEmail("lydia@example.com")
             .withPhone("9482427")
             .withRoomNumber("11-33")
+            .withStatus(Status.BOOKING)
             .build();
     public static final Guest GEORGE = new PersonBuilder()
             .withName("George Best")
             .withEmail("anna@example.com")
             .withPhone("9482442")
             .withRoomNumber("03-33")
+            .withStatus(Status.BOOKING)
             .build();
 
     // Manually added
@@ -90,6 +86,7 @@ public class TypicalPersons {
             .withEmail(VALID_EMAIL_AMY)
             .withPhone(VALID_PHONE_AMY)
             .withRoomNumber(VALID_ROOMNUMBER_AMY)
+            .withStatus(VALID_STATUS_AMY)
             .withRequests(VALID_REQUEST_FRIEND)
             .build();
     public static final Guest BOB = new PersonBuilder()
@@ -97,6 +94,7 @@ public class TypicalPersons {
             .withPhone(VALID_PHONE_BOB)
             .withEmail(VALID_EMAIL_BOB)
             .withRoomNumber(VALID_ROOMNUMBER_BOB)
+            .withStatus(VALID_STATUS_BOB)
             .withRequests(VALID_REQUEST_HUSBAND, VALID_REQUEST_FRIEND)
             .build();
 


### PR DESCRIPTION
This PR introduces a status field to the Guest model and adds two new commands:

- `check-in INDEX:` Updates a guest’s status to CHECKED_IN
- `check-out INDEX`: Updates a guest’s status to CHECKED_OUT
- It also enhances the UI to display the guest’s status with color-coded labels.

![image](https://github.com/user-attachments/assets/834ca4d4-8bcf-4b65-ae09-6cd40b2dfbb4)


🔧 **Major Changes**

- Added Status enum with values: BOOKING, CHECKED_IN, CHECKED_OUT
- Extended Guest to include a status field (default: BOOKING)
- Updated Guest constructor, equals, hashCode, toString, and JSON adapter
- Created new commands:
- CheckInCommand
- CheckOutCommand
- Modified PersonCard to display a stylized status label in the UI
- Updated FXML and CSS to reflect new styles for status badges
- Updated test utilities and JSON test data to include status

✅ **Tests Added**
- CheckInCommandTest
- CheckOutCommandTest
- CheckInCommandParserTest
- CheckOutCommandParserTest
- StatusTest

**How to Test**
- Add a new guest — should default to BOOKING status.
- Run `check-in 1 `→ status updates to CHECKED_IN
- Run `check-out 1` → status updates to CHECKED_OUT
- Guests should only display the corresponding status tags:
1. 🟡 BOOKING
2. 🟢 CHECKED_IN
3. 🔴 CHECKED_OUT


TODO: better oop / parent / abstract class for check-in/check-out parsers and their respective unit/integration tests