### PR TITLE
Add validation for Phone length

### DIFF
--- a/src/main/java/seedu/guestnote/model/guest/Phone.java
+++ b/src/main/java/seedu/guestnote/model/guest/Phone.java
@@ -11,8 +11,8 @@ public class Phone {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+            "Phone numbers should only contain numbers, and be between 4 and 17 digits long";
+    public static final String VALIDATION_REGEX = "\\d{4,17}";
     public final String value;
 
     /**

--- a/src/test/java/seedu/guestnote/model/guest/PhoneTest.java
+++ b/src/test/java/seedu/guestnote/model/guest/PhoneTest.java
@@ -27,23 +27,23 @@ public class PhoneTest {
         // invalid phone numbers
         assertFalse(Phone.isValidPhone("")); // empty string
         assertFalse(Phone.isValidPhone(" ")); // spaces only
-        assertFalse(Phone.isValidPhone("91")); // less than 3 numbers
+        assertFalse(Phone.isValidPhone("91")); // less than 4 numbers
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
 
         // valid phone numbers
-        assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
-        assertTrue(Phone.isValidPhone("93121534"));
-        assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
+        assertFalse(Phone.isValidPhone("911")); // 3 numbers
+        assertTrue(Phone.isValidPhone("93121534")); // 8 numbers
+        assertFalse(Phone.isValidPhone("124293842033123555")); // 18 numbers
     }
 
     @Test
     public void equals() {
-        Phone phone = new Phone("999");
+        Phone phone = new Phone("9999");
 
         // same values -> returns true
-        assertTrue(phone.equals(new Phone("999")));
+        assertTrue(phone.equals(new Phone("9999")));
 
         // same object -> returns true
         assertTrue(phone.equals(phone));
@@ -55,6 +55,6 @@ public class PhoneTest {
         assertFalse(phone.equals(5.0f));
 
         // different values -> returns false
-        assertFalse(phone.equals(new Phone("995")));
+        assertFalse(phone.equals(new Phone("9995")));
     }
 }


### PR DESCRIPTION
Resolves #116 

According to World Population Index: "Phone number length around the world ranges from 17 digits to only 4."
This PR adds validation that Phone must be digits and between length 4 and 16 in order to be valid. 