### PR TITLE
Make email comparisons case-insensitive for guest identity

### DIFF
--- a/src/main/java/seedu/guestnote/model/guest/Guest.java
+++ b/src/main/java/seedu/guestnote/model/guest/Guest.java
@@ -83,7 +83,7 @@ public class Guest {
         }
 
         return otherGuest != null
-                && otherGuest.getEmail().equals(getEmail());
+                && otherGuest.getEmail().value.equalsIgnoreCase(getEmail().value);
     }
 
     /**
@@ -104,7 +104,7 @@ public class Guest {
         Guest otherGuest = (Guest) other;
         return name.equals(otherGuest.name)
                 && phone.equals(otherGuest.phone)
-                && email.equals(otherGuest.email)
+                && email.value.equalsIgnoreCase(otherGuest.email.value)
                 && roomNumber.equals(otherGuest.roomNumber)
                 && status.equals(otherGuest.status)
                 && requests.equals(otherGuest.requests);


### PR DESCRIPTION
# Resolves #118 

In this PR:
- Updated isSameGuest() and equals() methods in Guest.java to perform case-insensitive comparison of emails
- Ensures that guests with the same email (ignoring case) are treated as the same person
- Prevents duplicate entries like alice@example.com and Alice@Example.com from being considered different guests

