### PR TITLE
Add restrictions to Email length

### DIFF
--- a/src/main/java/seedu/guestnote/model/guest/Email.java
+++ b/src/main/java/seedu/guestnote/model/guest/Email.java
@@ -9,13 +9,15 @@ import static seedu.guestnote.commons.util.AppUtil.checkArgument;
  */
 public class Email {
 
+    public static final int MAX_EMAIL_LENGTH = 254;
     private static final String SPECIAL_CHARACTERS = "+_.-";
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
             + "and adhere to the following constraints:\n"
-            + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
+            + "1. The entire email must not exceed 254 characters.\n"
+            + "2. The local-part should only contain alphanumeric characters and these special characters, excluding "
             + "the parentheses, (" + SPECIAL_CHARACTERS + "). The local-part may not start or end with any special "
             + "characters.\n"
-            + "2. This is followed by a '@' and then a domain name. The domain name is made up of domain labels "
+            + "3. This is followed by a '@' and then a domain name. The domain name is made up of domain labels "
             + "separated by periods.\n"
             + "The domain name must:\n"
             + "    - end with a domain label at least 2 characters long\n"
@@ -47,8 +49,8 @@ public class Email {
     /**
      * Returns if a given string is a valid email.
      */
-    public static boolean isValidEmail(String test) {
-        return test.matches(VALIDATION_REGEX);
+    public static boolean isValidEmail(String email) {
+        return email.length() <= MAX_EMAIL_LENGTH && email.matches(VALIDATION_REGEX);
     }
 
     @Override

--- a/src/test/java/seedu/guestnote/model/guest/EmailTest.java
+++ b/src/test/java/seedu/guestnote/model/guest/EmailTest.java
@@ -52,8 +52,11 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peterjack@example.com-")); // domain name ends with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.c")); // top level domain has less than two chars
         assertFalse(Email.isValidEmail("peterjack@.c")); // missing domain label between @ and .
-        String EmailOfLength255 = "ncdqvtzxapbrsicdggzukcstcpxuyjaanoqveaugxqtnbwispyxrusomdedoadhoubuhpdykhckbmzqrmjsjynobcbecqpfblnacnkzvqwlrwojqyqwvamvuawnoeljyxcwsyuoikfcijqlpkfeifjxrlfbjfykibaqaytvpvxuxfiesojnplibuhawwsaahzmqvpksvwrltbouzqpcssyorlizlnrlvgwjicduzzyyzhmezxpmuozybd@e.com";
-        assertFalse(Email.isValidEmail(EmailOfLength255)); // Beyond 254 characters.
+        String emailOfLengthTwoHundredAndFiftyFive =
+                "ncdqvtzxapbrsicdggzukcstcpxuyjaanoqveaugxqtnbwispyxrusomdedoadhoubuhpdykhckb"
+                + "mzqrmjsjynobcbecqpfblnacnkzvqwlrwojqyqwvamvuawnoeljyxcwsyuoikfcijqlpkfeifjxrlfbjfykibaqaytvpvx"
+                + "uxfiesojnplibuhawwsaahzmqvpksvwrltbouzqpcssyorlizlnrlvgwjicduzzyyzhmezxpmuozybd@e.com";
+        assertFalse(Email.isValidEmail(emailOfLengthTwoHundredAndFiftyFive)); // Beyond 254 characters.
 
         // valid email
         assertTrue(Email.isValidEmail("PeterJack_1190@example.com")); // underscore in local part
@@ -67,8 +70,11 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
         assertTrue(Email.isValidEmail("e1234567@u.nus.edu")); // more than one period in domain
-        String EmailOfLength254 = "ncdqvtzxapbrsicdggzukcstcpxuyjaanoqveaugxqtnbwispyxrusomdedoadhoubuhpdykhckbmzqrmjsjynobcbecqpfblnacnkzvqwlrwojqyqwvamvuawnoeljyxcwsyuoikfcijqlpkfeifjxrlfbjfykibaqaytvpvxuxfiesojnplibuhawwsaahzmqvpksvwrltbouzqpcssyorlizlnrlvgwjicduzzyyzhmezxpmuozyb@e.com";
-        assertTrue(Email.isValidEmail(EmailOfLength254)); // Within 254 characters.
+        String emailOfLengthTwoHundredandFiftyFour =
+                "ncdqvtzxapbrsicdggzukcstcpxuyjaanoqveaugxqtnbwispyxrusomdedoadhoubuhpdy"
+                + "khckbmzqrmjsjynobcbecqpfblnacnkzvqwlrwojqyqwvamvuawnoeljyxcwsyuoikfcijqlpkfeifjxrlfbjfyki"
+                + "baqaytvpvxuxfiesojnplibuhawwsaahzmqvpksvwrltbouzqpcssyorlizlnrlvgwjicduzzyyzhmezxpmuozyb@e.com";
+        assertTrue(Email.isValidEmail(emailOfLengthTwoHundredandFiftyFour)); // Within 254 characters.
     }
 
     @Test

--- a/src/test/java/seedu/guestnote/model/guest/EmailTest.java
+++ b/src/test/java/seedu/guestnote/model/guest/EmailTest.java
@@ -51,6 +51,9 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peterjack@-example.com")); // domain name starts with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.com-")); // domain name ends with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.c")); // top level domain has less than two chars
+        assertFalse(Email.isValidEmail("peterjack@.c")); // missing domain label between @ and .
+        String EmailOfLength255 = "ncdqvtzxapbrsicdggzukcstcpxuyjaanoqveaugxqtnbwispyxrusomdedoadhoubuhpdykhckbmzqrmjsjynobcbecqpfblnacnkzvqwlrwojqyqwvamvuawnoeljyxcwsyuoikfcijqlpkfeifjxrlfbjfykibaqaytvpvxuxfiesojnplibuhawwsaahzmqvpksvwrltbouzqpcssyorlizlnrlvgwjicduzzyyzhmezxpmuozybd@e.com";
+        assertFalse(Email.isValidEmail(EmailOfLength255)); // Beyond 254 characters.
 
         // valid email
         assertTrue(Email.isValidEmail("PeterJack_1190@example.com")); // underscore in local part
@@ -64,6 +67,8 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
         assertTrue(Email.isValidEmail("e1234567@u.nus.edu")); // more than one period in domain
+        String EmailOfLength254 = "ncdqvtzxapbrsicdggzukcstcpxuyjaanoqveaugxqtnbwispyxrusomdedoadhoubuhpdykhckbmzqrmjsjynobcbecqpfblnacnkzvqwlrwojqyqwvamvuawnoeljyxcwsyuoikfcijqlpkfeifjxrlfbjfykibaqaytvpvxuxfiesojnplibuhawwsaahzmqvpksvwrltbouzqpcssyorlizlnrlvgwjicduzzyyzhmezxpmuozyb@e.com";
+        assertTrue(Email.isValidEmail(EmailOfLength254)); // Within 254 characters.
     }
 
     @Test


### PR DESCRIPTION
# Resolves #120 

In this PR: 
- Added a length check to Email.java to ensure email addresses do not exceed 254 characters, in accordance with [RFC 5321](https://datatracker.ietf.org/doc/html/rfc5321)
- Updated MESSAGE_CONSTRAINTS to document the new restriction
- Prevents invalidly long emails from being accepted by the AddCommand and ensures closer alignment with real-world standards