### PR TITLE
Improve error message for duplicate requests in AddCommand

### DIFF
--- a/src/main/java/seedu/guestnote/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/guestnote/logic/parser/AddCommandParser.java
@@ -27,7 +27,7 @@ import seedu.guestnote.model.request.exceptions.DuplicateRequestException;
  */
 public class AddCommandParser implements Parser<AddCommand> {
 
-    public static String DUPLICATE_REQUEST_MESSAGE = "Duplicate requests are not allowed";
+    public static final String DUPLICATE_REQUEST_MESSAGE = "Duplicate requests are not allowed";
 
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand

--- a/src/main/java/seedu/guestnote/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/guestnote/logic/parser/AddCommandParser.java
@@ -20,11 +20,14 @@ import seedu.guestnote.model.guest.RoomNumber;
 import seedu.guestnote.model.guest.Status;
 import seedu.guestnote.model.request.Request;
 import seedu.guestnote.model.request.UniqueRequestList;
+import seedu.guestnote.model.request.exceptions.DuplicateRequestException;
 
 /**
  * Parses input arguments and creates a new AddCommand object
  */
 public class AddCommandParser implements Parser<AddCommand> {
+
+    public static String DUPLICATE_REQUEST_MESSAGE = "Duplicate requests are not allowed";
 
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand
@@ -54,7 +57,12 @@ public class AddCommandParser implements Parser<AddCommand> {
         Status status = Status.BOOKED;
         List<Request> requestList = ParserUtil.parseRequests(argMultimap.getAllValues(PREFIX_REQUEST));
         UniqueRequestList requests = new UniqueRequestList();
-        requests.addAll(requestList);
+
+        try {
+            requests.addAll(requestList);
+        } catch (DuplicateRequestException e) {
+            throw new ParseException(DUPLICATE_REQUEST_MESSAGE);
+        }
 
         Guest guest = new Guest(name, phone, email, roomNumber, status, requests);
 

--- a/src/main/java/seedu/guestnote/model/request/UniqueRequestList.java
+++ b/src/main/java/seedu/guestnote/model/request/UniqueRequestList.java
@@ -36,7 +36,7 @@ public class UniqueRequestList implements Iterable<Request> {
      * Adds a request to the list.
      * The request must not already exist in the list.
      */
-    public void add(Request toAdd) {
+    public void add(Request toAdd) throws DuplicateRequestException {
         requireNonNull(toAdd);
         if (contains(toAdd)) {
             throw new DuplicateRequestException(toAdd.toString());

--- a/src/test/java/seedu/guestnote/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/guestnote/logic/parser/AddCommandParserTest.java
@@ -157,6 +157,14 @@ public class AddCommandParserTest {
     }
 
     @Test
+    public void parse_duplicateRequests_throwsParseException() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
+
+        assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_EMAIL_BOB
+                + VALID_REQUEST_FRIEND + VALID_REQUEST_FRIEND, expectedMessage);
+    }
+
+    @Test
     public void parse_invalidValue_failure() {
         // invalid name
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB


### PR DESCRIPTION
# Resolves #125 

In this PR, I fixed misleading error shown when a guest with duplicate rq/ entries is added.

Previously, the app displayed a generic “Invalid command format” message, even though the command format was correct but the duplicate request was cause for failure. The parser now catches DuplicateRequestException and rethrows it as a ParseException with a clearer message `“Duplicate requests are not allowed”`

This improves user experience by accurately indicating the cause of the error