### PR TITLE
Make request comparison case-insensitive

### DIFF
--- a/src/main/java/seedu/guestnote/model/request/Request.java
+++ b/src/main/java/seedu/guestnote/model/request/Request.java
@@ -42,7 +42,7 @@ public class Request {
         }
 
         return otherRequest != null
-                && otherRequest.requestName.equals(requestName);
+                && otherRequest.requestName.equalsIgnoreCase(requestName);
     }
 
     @Override
@@ -57,7 +57,7 @@ public class Request {
         }
 
         Request otherRequest = (Request) other;
-        return requestName.equals(otherRequest.requestName);
+        return requestName.equalsIgnoreCase(otherRequest.requestName);
     }
 
     @Override


### PR DESCRIPTION
# Resolves #127 

Fixed issue where request strings were treated as case-sensitive (e.g. "Extra pillow" and "extra pillow" were considered different)
	•	Updated Request logic to treat requests as case-insensitive when checking for duplicates
	•	This prevents semantically identical requests with different casing from being added multiple times
	•	Improves data consistency and reduces redundant request execution