### PR TITLE
Allow partial name matches in list

### DIFF
--- a/src/main/java/seedu/guestnote/commons/util/StringUtil.java
+++ b/src/main/java/seedu/guestnote/commons/util/StringUtil.java
@@ -65,4 +65,11 @@ public class StringUtil {
             return false;
         }
     }
+
+    public static boolean containsSubstringIgnoreCase(String fullName, String keyword) {
+        requireNonNull(fullName);
+        requireNonNull(keyword);
+
+        return fullName.toLowerCase().contains(keyword.toLowerCase());
+    }
 }

--- a/src/main/java/seedu/guestnote/commons/util/StringUtil.java
+++ b/src/main/java/seedu/guestnote/commons/util/StringUtil.java
@@ -66,6 +66,10 @@ public class StringUtil {
         }
     }
 
+    /**
+     * Returns true if {@code fullName} contains {@code keyword} as a substring.
+     * The comparison is case-insensitive.
+     */
     public static boolean containsSubstringIgnoreCase(String fullName, String keyword) {
         requireNonNull(fullName);
         requireNonNull(keyword);

--- a/src/main/java/seedu/guestnote/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/guestnote/logic/commands/ListCommand.java
@@ -39,10 +39,12 @@ public class ListCommand extends Command {
         if (predicate == null) {
             // Default behavior: list all guests
             model.updateFilteredGuestList(PREDICATE_SHOW_ALL_GUESTS);
+            return new CommandResult(MESSAGE_SUCCESS);
         } else {
             // Search behavior: filter list based on the predicate
             model.updateFilteredGuestList(predicate);
+            return new CommandResult(MESSAGE_SUCCESS + " (filtered)");
         }
-        return new CommandResult(MESSAGE_SUCCESS);
+
     }
 }

--- a/src/main/java/seedu/guestnote/model/guest/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/guestnote/model/guest/NameContainsKeywordsPredicate.java
@@ -19,7 +19,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Guest> {
     @Override
     public boolean test(Guest guest) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(guest.getName().fullName, keyword));
+                .anyMatch(keyword -> StringUtil.containsSubstringIgnoreCase(guest.getName().fullName, keyword));
     }
 
     @Override


### PR DESCRIPTION
Previously, if guestbook contained guest named Alexander, `list Alex` would not show Alexander. Now, it does, by loosening match constraint to partial matches. 