### PR TITLE
Fix partial match for request field

### DIFF
--- a/src/main/java/seedu/guestnote/model/guest/FieldContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/guestnote/model/guest/FieldContainsKeywordsPredicate.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import seedu.guestnote.commons.util.StringUtil;
 
@@ -68,20 +70,28 @@ public class FieldContainsKeywordsPredicate<T> implements Predicate<Guest> {
 
     /**
      * Helper method that checks if the concatenated string of array elements contains
-     * the full phrase formed by joining all keywords.
+     * keywords on a word-by-word basis.
      * This ensures that for array fields (like requests), the complete phrase is matched.
      */
     private boolean arrayContainsKeyword(Object[] arr, List<String> keywords) {
-        StringBuilder sb = new StringBuilder();
+        // Join keywords into a normalized search phrase.
+        String normalizedSearch = String.join(" ", keywords).toLowerCase().trim()
+                .replaceAll("\\s+", " ");
+        // Prepare a regex pattern with word boundaries.
+        Pattern pattern = Pattern.compile("\\b" + Pattern.quote(normalizedSearch) + "\\b");
+
+        // Check each element of the array.
         for (Object element : arr) {
             if (element != null) {
-                sb.append(element.toString().toLowerCase()).append(" ");
+                String normalizedElement = element.toString().toLowerCase().trim()
+                        .replaceAll("\\s+", " ");
+                Matcher matcher = pattern.matcher(normalizedElement);
+                if (matcher.find()) {
+                    return true;
+                }
             }
         }
-        String combined = sb.toString();
-        // Join all keywords with a space to form the full search phrase.
-        String joinedKeywords = String.join(" ", keywords).toLowerCase();
-        return combined.contains(joinedKeywords);
+        return false;
     }
     @Override
     public String toString() {


### PR DESCRIPTION
This PR addresses two key issues in the FieldContainsKeywordsPredicate:
	•	Optional Handling:
The predicate now correctly handles cases where the field extractor returns an Optional. If the field value is an instance of Optional, the code checks whether it contains a value; if not, it returns false. This ensures that predicates for fields like phone numbers (which now return Optional<Phone>) behave correctly.
	•	Whole Word Matching for Array Fields:
The logic for matching keywords in array fields has been updated to enforce whole word matching. Instead of performing a simple substring check, the updated implementation uses regex with word boundaries. This prevents partial matches (e.g., typing “x” will no longer match a request containing “extra”) and ensures that the full search phrase is matched as intended.

Additionally, new test cases have been added to cover:
	•	The branch where a field value is an Optional (both when a value is present and when it’s empty).
	•	The updated behavior of whole word matching in array fields.