### PR TITLE
Fix bug to ensure -ri and -rq are exclusive, and ri is not duplicate

### DIFF
--- a/src/main/java/seedu/guestnote/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/guestnote/logic/commands/EditCommand.java
@@ -118,8 +118,6 @@ public class EditCommand extends Command {
         UniqueRequestList updatedRequests = new UniqueRequestList();
         updatedRequests.setRequests(guestToEdit.getRequests());
 
-        editGuestDescriptor.getRequestsToAdd().ifPresent(updatedRequests::addAll);
-        editGuestDescriptor.getRequestsToDelete().ifPresent(updatedRequests::removeAll);
         editGuestDescriptor.getRequestIndexesToDelete().ifPresent(indexes -> {
             List<Request> requests = updatedRequests.asUnmodifiableObservableList();
             for (Index idx : indexes) {
@@ -133,6 +131,8 @@ public class EditCommand extends Command {
 
             updatedRequests.removeAll(requestsToDeleteList);
         });
+        editGuestDescriptor.getRequestsToDelete().ifPresent(updatedRequests::removeAll);
+        editGuestDescriptor.getRequestsToAdd().ifPresent(updatedRequests::addAll);
 
         return new Guest(updatedName, updatedPhone, updatedEmail, updatedRoomNumber, updatedStatus, updatedRequests);
     }

--- a/src/main/java/seedu/guestnote/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/guestnote/logic/parser/EditCommandParser.java
@@ -46,8 +46,12 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(
-                PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ROOMNUMBER
+                PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ROOMNUMBER, PREFIX_DELETE_REQ_INDEX
         );
+        if (argMultimap.getValue(PREFIX_DELETE_REQ).isPresent()
+                && argMultimap.getValue(PREFIX_DELETE_REQ_INDEX).isPresent()) {
+            throw new ParseException("Cannot use " + PREFIX_DELETE_REQ_INDEX + " " + PREFIX_DELETE_REQ + " together.");
+        }
 
         EditGuestDescriptor editGuestDescriptor = new EditGuestDescriptor();
 

--- a/src/test/java/seedu/guestnote/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/guestnote/logic/commands/EditCommandTest.java
@@ -242,6 +242,26 @@ public class EditCommandTest {
     }
 
     @Test
+    public void execute_deleteIndexOutOfBoundsAndAddRequest_failure() {
+        // Set up the guest with 3 initial requests
+        Guest originalGuest = new GuestBuilder()
+                .withName("Alex Yeoh")
+                .withRequests("hello", "hello2", "hello3")
+                .build();
+        model.setGuest(model.getFilteredGuestList().get(0), originalGuest);
+
+        // Attempt to delete index 4 (invalid), then add "hello4"
+        // Deletion of index 4 should give error
+        EditGuestDescriptor descriptor = new EditGuestDescriptorBuilder()
+                .withRequestsToAdd("hello4")
+                .withRequestIndexesToDelete("4")
+                .build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_GUEST, descriptor);
+        String expectedMessage = "This request does not exist in the guest: Index Number 4";
+        assertCommandFailure(editCommand, model, expectedMessage);
+    }
+
+    @Test
     public void equals() {
         final EditCommand standardCommand = new EditCommand(INDEX_FIRST_GUEST, DESC_AMY);
 

--- a/src/test/java/seedu/guestnote/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/guestnote/logic/commands/EditCommandTest.java
@@ -205,6 +205,41 @@ public class EditCommandTest {
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_REQUEST + ": [friend]");
     }
 
+    @Test
+    public void execute_addRequestAndDeleteRequestIndex_success() {
+        // Set up the guest with initial requests
+        Guest originalGuest = new GuestBuilder()
+                .withName("Alex Yeoh")
+                .withPhone("99272758")
+                .withEmail("alexyeoh@example.com")
+                .withRoomNumber("23-32")
+                .withRequests("Late check in", "Hello4")
+                .build();
+        model.setGuest(model.getFilteredGuestList().get(0), originalGuest);
+
+        // Prepare expected guest after editing
+        Guest editedGuest = new GuestBuilder()
+                .withName("Alex Yeoh")
+                .withPhone("99272758")
+                .withEmail("alexyeoh@example.com")
+                .withRoomNumber("23-32")
+                .withRequests("Late check in", "Hello5") // Hello4 is removed (index 2), Hello5 is added
+                .build();
+
+        // Delete index 2 removes "Hello4", add "Hello5"
+        EditGuestDescriptor descriptor = new EditGuestDescriptorBuilder()
+                .withRequestsToAdd("Hello5")
+                .withRequestIndexesToDelete("2")
+                .build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_GUEST, descriptor);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_GUEST_SUCCESS, Messages.format(editedGuest));
+
+        Model expectedModel = new ModelManager(new GuestNote(model.getGuestNote()), new UserPrefs());
+        expectedModel.setGuest(model.getFilteredGuestList().get(0), editedGuest);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/guestnote/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/guestnote/logic/commands/EditCommandTest.java
@@ -262,6 +262,26 @@ public class EditCommandTest {
     }
 
     @Test
+    public void execute_deleteNotFoundRequestAndAddRequest_failure() {
+        // Set up the guest with 3 initial requests
+        Guest originalGuest = new GuestBuilder()
+                .withName("Alex Yeoh")
+                .withRequests("hello", "hello2", "hello3")
+                .build();
+        model.setGuest(model.getFilteredGuestList().get(0), originalGuest);
+
+        // Attempt to delete "hello4" (invalid), then add "hello5"
+        // Deletion of request "hello4" should give error
+        EditGuestDescriptor descriptor = new EditGuestDescriptorBuilder()
+                .withRequestsToAdd("hello5")
+                .withRequestsToDelete("hello4")
+                .build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_GUEST, descriptor);
+        String expectedMessage = "This request does not exist in the guest: [hello4]";
+        assertCommandFailure(editCommand, model, expectedMessage);
+    }
+
+    @Test
     public void equals() {
         final EditCommand standardCommand = new EditCommand(INDEX_FIRST_GUEST, DESC_AMY);
 

--- a/src/test/java/seedu/guestnote/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/guestnote/logic/parser/EditCommandParserTest.java
@@ -21,8 +21,12 @@ import static seedu.guestnote.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.guestnote.logic.commands.CommandTestUtil.VALID_REQUEST_EXTRAPILLOW;
 import static seedu.guestnote.logic.commands.CommandTestUtil.VALID_REQUEST_SEAVIEW;
 import static seedu.guestnote.logic.parser.CliSyntax.PREFIX_ADD_REQ;
+import static seedu.guestnote.logic.parser.CliSyntax.PREFIX_DELETE_REQ;
+import static seedu.guestnote.logic.parser.CliSyntax.PREFIX_DELETE_REQ_INDEX;
 import static seedu.guestnote.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.guestnote.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.guestnote.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.guestnote.logic.parser.CliSyntax.PREFIX_ROOMNUMBER;
 import static seedu.guestnote.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.guestnote.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.guestnote.testutil.TypicalIndexes.INDEX_FIRST_GUEST;
@@ -187,4 +191,56 @@ public class EditCommandParserTest {
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL));
     }
 
+    @Test
+    public void parse_multipleRiFields_failure() {
+        // multiple ri fields
+        Index targetIndex = INDEX_FIRST_GUEST;
+        String userInput = targetIndex.getOneBased() + " " + PREFIX_DELETE_REQ_INDEX + "1 "
+                + PREFIX_DELETE_REQ_INDEX + "2";
+        assertParseFailure(parser, userInput,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DELETE_REQ_INDEX));
+    }
+
+    @Test
+    public void parse_deleteReqIndexAndDeleteReq_failure() {
+        Index targetIndex = INDEX_FIRST_GUEST;
+        String userInput = targetIndex.getOneBased() + " " + PREFIX_DELETE_REQ_INDEX + "1 "
+                + PREFIX_DELETE_REQ + "Extra pillow";
+
+        assertParseFailure(parser, userInput,
+                "Cannot use " + PREFIX_DELETE_REQ_INDEX + " " + PREFIX_DELETE_REQ + " together.");
+    }
+
+    @Test
+    public void parse_duplicateNonRequestPrefixes_failure() {
+        Index targetIndex = INDEX_FIRST_GUEST;
+
+        // Duplicate name prefix
+        String userInput = targetIndex.getOneBased() + " "
+                + "n/Alice n/Amy";
+
+        assertParseFailure(parser, userInput,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
+
+        // Duplicate phone prefix
+        userInput = targetIndex.getOneBased() + " "
+                + "p/12345678 p/87654321";
+
+        assertParseFailure(parser, userInput,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
+
+        // Duplicate email prefix
+        userInput = targetIndex.getOneBased() + " "
+                + "e/alice@example.com e/bob@example.com";
+
+        assertParseFailure(parser, userInput,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL));
+
+        // Duplicate room number prefix
+        userInput = targetIndex.getOneBased() + " "
+                + "r/101 r/202";
+
+        assertParseFailure(parser, userInput,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ROOMNUMBER));
+    }
 }

--- a/src/test/java/seedu/guestnote/testutil/EditGuestDescriptorBuilder.java
+++ b/src/test/java/seedu/guestnote/testutil/EditGuestDescriptorBuilder.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
+import seedu.guestnote.commons.core.index.Index;
 import seedu.guestnote.logic.commands.EditCommand.EditGuestDescriptor;
 import seedu.guestnote.model.guest.Email;
 import seedu.guestnote.model.guest.Guest;
@@ -91,6 +92,18 @@ public class EditGuestDescriptorBuilder {
     public EditGuestDescriptorBuilder withRequestsToDelete(String... requests) {
         List<Request> requestList = new ArrayList<>(Stream.of(requests).map(Request::new).toList());
         descriptor.setRequestsToDelete(requestList);
+        return this;
+    }
+
+    /**
+     * Parses the {@code indexes} into a {@code List<Index>} and sets them as request indexes **to remove**
+     * in the {@code EditGuestDescriptor} that we are building.
+     */
+    public EditGuestDescriptorBuilder withRequestIndexesToDelete(String... indexes) {
+        List<Index> indexList = new ArrayList<>(Stream.of(indexes)
+                .map(index -> Index.fromOneBased(Integer.parseInt(index)))
+                .toList());
+        descriptor.setRequestIndexesToDelete(indexList);
         return this;
     }
 


### PR DESCRIPTION
#176 #252 

Also, fixed bug where 
- Current request list is length 3, ["hello", "hello2", "hello3"]
- `edit 1 +rq/hello4 -ri/4` does nothing, because request is added then immediately deleted
- Fix was done by performing all deletes first (either ri or rq), then adds
