### PR TITLE
Fix issue where a guest with empty phone number cause find to fail

### DIFF
--- a/src/main/java/seedu/guestnote/model/guest/FieldContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/guestnote/model/guest/FieldContainsKeywordsPredicate.java
@@ -30,10 +30,15 @@ public class FieldContainsKeywordsPredicate<T> implements Predicate<Guest> {
         this.fieldExtractor = fieldExtractor;
     }
 
+    /**
+     * Tests whether the field of a Guest object contains any of the given keywords.
+     * @param guest The Guest object to test.
+     * @return true if the field contains any of the keywords, false otherwise.
+     */
     @Override
     public boolean test(Guest guest) {
         T fieldValue = fieldExtractor.apply(guest);
-        if (fieldValue instanceof Optional<?> optionalValue) {
+        if (fieldValue instanceof Optional<?> optionalValue) {//pattern matching
             if (!optionalValue.isPresent()) {
                 return false;
             }

--- a/src/main/java/seedu/guestnote/model/guest/FieldContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/guestnote/model/guest/FieldContainsKeywordsPredicate.java
@@ -33,8 +33,7 @@ public class FieldContainsKeywordsPredicate<T> implements Predicate<Guest> {
     @Override
     public boolean test(Guest guest) {
         T fieldValue = fieldExtractor.apply(guest);
-        if (fieldValue instanceof Optional) {
-            Optional<?> optionalValue = (Optional<?>) fieldValue;
+        if (fieldValue instanceof Optional<?> optionalValue) {
             if (!optionalValue.isPresent()) {
                 return false;
             }
@@ -47,7 +46,11 @@ public class FieldContainsKeywordsPredicate<T> implements Predicate<Guest> {
             Object[] arr = (Object[]) fieldValue;
             return arrayContainsKeyword(arr, keywords);
         } else {
-            String fieldString = fieldValue.toString().trim();
+            String temp = fieldValue.toString();
+            if (temp == null) {
+                return false;
+            }
+            String fieldString = temp.trim();
             return keywords.stream()
                     .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(fieldString, keyword.trim()));
         }

--- a/src/main/java/seedu/guestnote/model/guest/FieldContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/guestnote/model/guest/FieldContainsKeywordsPredicate.java
@@ -38,7 +38,7 @@ public class FieldContainsKeywordsPredicate<T> implements Predicate<Guest> {
     @Override
     public boolean test(Guest guest) {
         T fieldValue = fieldExtractor.apply(guest);
-        if (fieldValue instanceof Optional<?> optionalValue) {//pattern matching
+        if (fieldValue instanceof Optional<?> optionalValue) { //pattern matching
             if (!optionalValue.isPresent()) {
                 return false;
             }
@@ -52,9 +52,6 @@ public class FieldContainsKeywordsPredicate<T> implements Predicate<Guest> {
             return arrayContainsKeyword(arr, keywords);
         } else {
             String temp = fieldValue.toString();
-            if (temp == null) {
-                return false;
-            }
             String fieldString = temp.trim();
             return keywords.stream()
                     .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(fieldString, keyword.trim()));

--- a/src/main/java/seedu/guestnote/model/guest/FieldContainsSubstringsPredicate.java
+++ b/src/main/java/seedu/guestnote/model/guest/FieldContainsSubstringsPredicate.java
@@ -45,7 +45,11 @@ public class FieldContainsSubstringsPredicate<T> implements Predicate<Guest> {
             Object[] arr = (Object[]) fieldValue;
             return arrayContainsKeyword(arr, keywords);
         } else {
-            String fieldString = fieldValue.toString().trim();
+            String temp = fieldValue.toString();
+            if (temp == null) {
+                return false;
+            }
+            String fieldString = temp.trim();
             return keywords.stream()
                     .anyMatch(keyword -> StringUtil.containsSubstringIgnoreCase(fieldString, keyword.trim()));
         }

--- a/src/main/java/seedu/guestnote/model/guest/FieldContainsSubstringsPredicate.java
+++ b/src/main/java/seedu/guestnote/model/guest/FieldContainsSubstringsPredicate.java
@@ -35,7 +35,7 @@ public class FieldContainsSubstringsPredicate<T> implements Predicate<Guest> {
     @Override
     public boolean test(Guest guest) {
         T fieldValue = fieldExtractor.apply(guest);
-        if (fieldValue instanceof Optional<?> optionalValue) {//pattern matching
+        if (fieldValue instanceof Optional<?> optionalValue) { //pattern matching
             if (!optionalValue.isPresent()) {
                 return false;
             }

--- a/src/main/java/seedu/guestnote/model/guest/FieldContainsSubstringsPredicate.java
+++ b/src/main/java/seedu/guestnote/model/guest/FieldContainsSubstringsPredicate.java
@@ -28,11 +28,14 @@ public class FieldContainsSubstringsPredicate<T> implements Predicate<Guest> {
         this.fieldExtractor = fieldExtractor;
     }
 
+    /**
+     * @param guest the input argument
+     * @return
+     */
     @Override
     public boolean test(Guest guest) {
         T fieldValue = fieldExtractor.apply(guest);
-        if (fieldValue instanceof Optional) {
-            Optional<?> optionalValue = (Optional<?>) fieldValue;
+        if (fieldValue instanceof Optional<?> optionalValue) {//pattern matching
             if (!optionalValue.isPresent()) {
                 return false;
             }


### PR DESCRIPTION
Add one more check before trimming in FieldContainsKeyWordsPredicate and FieldContainsSubstringPredicate, if it is null, return false. 
This is a rather brainless fix as I did not manage to find the root cause of this issue, all methods seems to be handling the optional wrapper well. Given the time constraints, will just do this fix first, will continue to pound my head on the table to think abt this bug. 