### PR TITLE
Update Phone Constraints

### DIFF
--- a/src/main/java/seedu/guestnote/model/guest/Phone.java
+++ b/src/main/java/seedu/guestnote/model/guest/Phone.java
@@ -11,7 +11,7 @@ public class Phone {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should contain 4 to 20 digits";
+            "Phone numbers should contain 4 to 20 digits and should not have leading/trailing whitespace";
     public static final String VALIDATION_REGEX = "^\\+?[\\d ]+$";
     public final String value;
 
@@ -35,6 +35,10 @@ public class Phone {
      */
     public static boolean isValidPhone(String test) {
         if (!test.matches(VALIDATION_REGEX)) {
+            return false;
+        }
+        // Reject if starts or ends with whitespace
+        if (!test.equals(test.trim())) {
             return false;
         }
 

--- a/src/main/java/seedu/guestnote/model/guest/Phone.java
+++ b/src/main/java/seedu/guestnote/model/guest/Phone.java
@@ -11,8 +11,8 @@ public class Phone {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and be between 4 and 17 digits long";
-    public static final String VALIDATION_REGEX = "\\d{4,17}";
+            "Phone numbers should contain 4 to 20 digits";
+    public static final String VALIDATION_REGEX = "^\\+?[\\d ]+$";
     public final String value;
 
     /**
@@ -34,7 +34,13 @@ public class Phone {
      * Returns true if a given string is a valid phone number.
      */
     public static boolean isValidPhone(String test) {
-        return test.matches(VALIDATION_REGEX);
+        if (!test.matches(VALIDATION_REGEX)) {
+            return false;
+        }
+
+        // Count only the digits
+        int digitCount = test.replaceAll("\\D", "").length();
+        return digitCount >= 4 && digitCount <= 20;
     }
 
     @Override

--- a/src/main/java/seedu/guestnote/model/guest/Phone.java
+++ b/src/main/java/seedu/guestnote/model/guest/Phone.java
@@ -37,10 +37,6 @@ public class Phone {
         if (!test.matches(VALIDATION_REGEX)) {
             return false;
         }
-        // Reject if starts or ends with whitespace
-        if (!test.equals(test.trim())) {
-            return false;
-        }
 
         // Count only the digits
         int digitCount = test.replaceAll("\\D", "").length();

--- a/src/main/java/seedu/guestnote/model/guest/Phone.java
+++ b/src/main/java/seedu/guestnote/model/guest/Phone.java
@@ -11,7 +11,7 @@ public class Phone {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should contain 4 to 20 digits and should not have leading/trailing whitespace";
+            "Phone numbers should contain 4 to 20 digits";
     public static final String VALIDATION_REGEX = "^\\+?[\\d ]+$";
     public final String value;
 

--- a/src/test/java/seedu/guestnote/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/guestnote/logic/parser/ParserUtilTest.java
@@ -20,7 +20,7 @@ import seedu.guestnote.model.guest.Phone;
 import seedu.guestnote.model.request.Request;
 
 public class ParserUtilTest {
-    private static final String INVALID_NAME = "R@chel";
+    private static final String INVALID_NAME = "R!chel";
     private static final String INVALID_PHONE = "+651234567890123456781";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_REQUEST = "#friend";

--- a/src/test/java/seedu/guestnote/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/guestnote/logic/parser/ParserUtilTest.java
@@ -21,7 +21,7 @@ import seedu.guestnote.model.request.Request;
 
 public class ParserUtilTest {
     private static final String INVALID_NAME = "R@chel";
-    private static final String INVALID_PHONE = "+651234";
+    private static final String INVALID_PHONE = "+651234567890123456781";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_REQUEST = "#friend";
     private static final String VALID_NAME = "Rachel Walker";

--- a/src/test/java/seedu/guestnote/model/guest/PhoneTest.java
+++ b/src/test/java/seedu/guestnote/model/guest/PhoneTest.java
@@ -30,12 +30,11 @@ public class PhoneTest {
         assertFalse(Phone.isValidPhone("91")); // less than 4 numbers
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
-        assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
 
         // valid phone numbers
-        assertFalse(Phone.isValidPhone("911")); // 3 numbers
+        assertTrue(Phone.isValidPhone("9111")); // 3 numbers
         assertTrue(Phone.isValidPhone("93121534")); // 8 numbers
-        assertFalse(Phone.isValidPhone("124293842033123555")); // 18 numbers
+        assertTrue(Phone.isValidPhone("12429384203312355")); // 18 numbers
     }
 
     @Test

--- a/src/test/java/seedu/guestnote/storage/JsonAdaptedGuestTest.java
+++ b/src/test/java/seedu/guestnote/storage/JsonAdaptedGuestTest.java
@@ -18,7 +18,7 @@ import seedu.guestnote.model.guest.Phone;
 import seedu.guestnote.model.guest.RoomNumber;
 
 public class JsonAdaptedGuestTest {
-    private static final String INVALID_NAME = "R@chel";
+    private static final String INVALID_NAME = "R!chel";
     private static final String INVALID_PHONE = "123456789012345678901";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_ROOMNUMBER = " ";

--- a/src/test/java/seedu/guestnote/storage/JsonAdaptedGuestTest.java
+++ b/src/test/java/seedu/guestnote/storage/JsonAdaptedGuestTest.java
@@ -19,7 +19,7 @@ import seedu.guestnote.model.guest.RoomNumber;
 
 public class JsonAdaptedGuestTest {
     private static final String INVALID_NAME = "R@chel";
-    private static final String INVALID_PHONE = "+651234";
+    private static final String INVALID_PHONE = "123456789012345678901";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_ROOMNUMBER = " ";
     private static final String INVALID_REQUEST = "#friend";


### PR DESCRIPTION
Previously, phone validation was as follows:
- Only made up of digits
- Between 4 and 17 digits long

Now, the updated phone validation is as follows:
- Allow phone to start off with '+'
- Allow white spaces optionally anywhere in the phone field. Trailing or leading whitespaces are allowed and they are automatically trimmed. 
- Total number if digits (inc. country code should be between 4 and 20. Reason being that internationally, phone numbers are between 4 and 17 length. Country codes should be 1, 2, or 3 digits long according to International Telecommunication Union (ITU). Hence, maximum length allowed is 17 to account for country code added. Minimum is 4 to account for no country code added. 

Resolves #263