### PR TITLE
Add error detection to EditCommand

### DIFF
--- a/src/main/java/seedu/guestnote/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/guestnote/logic/parser/EditCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.guestnote.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.guestnote.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.guestnote.logic.parser.CliSyntax.PREFIX_ADD_REQ;
 import static seedu.guestnote.logic.parser.CliSyntax.PREFIX_DELETE_REQ;
 import static seedu.guestnote.logic.parser.CliSyntax.PREFIX_DELETE_REQ_INDEX;
@@ -12,6 +13,7 @@ import static seedu.guestnote.logic.parser.CliSyntax.PREFIX_ROOMNUMBER;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import seedu.guestnote.commons.core.index.Index;
 import seedu.guestnote.logic.commands.EditCommand;
@@ -38,6 +40,10 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         Index index;
 
+        if (!isAtLeastOnePrefixPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ROOMNUMBER,
+                PREFIX_ADD_REQ, PREFIX_DELETE_REQ, PREFIX_DELETE_REQ_INDEX)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
+        }
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
@@ -102,6 +108,10 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         List<Request> requestList = ParserUtil.parseRequests(requests);
         return Optional.of(requestList);
+    }
+
+    private static boolean isAtLeastOnePrefixPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).anyMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
 }


### PR DESCRIPTION
Resolves #289 

In this PR, I added a function that checks if at least one of the arguments are given (name, email, phone, req to add, req to delete, or delete req index). If at least one is present, the function returns true. otherwise, it returns false. 

If the function returns false, it will throw a parse exception that will display the correct error message
<img width="1085" alt="Screenshot 2025-04-07 at 11 45 00 PM" src="https://github.com/user-attachments/assets/cde9d404-b890-427c-91c6-c0de1ef03969" />
